### PR TITLE
Use signal as exit handler, only in main thread

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main  
     tags:
-      - 'refs/tags/v*' 
+      - 'v*' 
 
 jobs:
   build:

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -23,7 +23,6 @@ jobs:
 
     - name: Create Virtualenv and Build Wheel
       run: |
-        python -m venv venv
-        source venv/bin/activate
+        python -m venv .venv
         python setup.py venv
         python setup.py bdist_wheel

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -18,10 +18,8 @@ jobs:
 
     - name: Install dependencies
       run: |
-        sudo apt-get update
-        sudo apt-get install make
         python -m pip install --upgrade pip
-        python -m pip install wheel venv
+        python -m pip install wheel
 
     - name: Create Virtualenv and Build Wheel
       run: |

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - main  
+    tags:
+      - 'refs/tags/v*' 
 
 jobs:
   build:
@@ -32,3 +34,37 @@ jobs:
       with:
         name: python-wheel
         path: dist/*.whl
+
+
+  release:
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/v')  # Führe diesen Job nur aus, wenn ein Tag gepusht wird
+    steps:
+    - uses: actions/checkout@v4
+    - name: Download Wheel from Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        name: python-wheel
+        path: dist
+
+    - name: Create Release
+      uses: actions/create-release@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        tag_name: ${{ github.ref }}
+        release_name: Release ${{ github.ref }}
+        body: 'New release ${{ github.ref }}'
+        draft: false
+        prerelease: true
+
+    - name: Upload Release Asset
+      uses: actions/upload-release-asset@v1
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      with:
+        upload_url: ${{ steps.create_release.outputs.upload_url }}
+        asset_path: ./dist/*.whl
+        asset_name: shunk-${{ github.ref }}.whl
+        asset_content_type: application/octet-stream

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -66,6 +66,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: ./dist/*.whl
+        asset_path: dist/*
         asset_name: shunk-${{ github.ref }}.whl
         asset_content_type: application/octet-stream

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -4,8 +4,6 @@ on:
   push:
     branches:
       - main  
-    tags:
-      - 'v*' 
 
 jobs:
   build:
@@ -35,37 +33,3 @@ jobs:
         name: python-wheel
         path: dist/*.whl
 
-
-  release:
-    needs: build
-    runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/v')  # Führe diesen Job nur aus, wenn ein Tag gepusht wird
-    steps:
-    - uses: actions/checkout@v4
-    - name: Download Wheel from Artifacts
-      uses: actions/download-artifact@v4
-      with:
-        name: python-wheel
-        path: dist
-
-    - name: Create Release
-      uses: actions/create-release@v1
-      id: create_release
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        tag_name: ${{ github.ref }}
-        release_name: Release ${{ github.ref }}
-        body: 'New release ${{ github.ref }}'
-        draft: false
-        prerelease: true
-
-    - name: Upload Release Asset
-      uses: actions/upload-release-asset@v1
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      with:
-        upload_url: ${{ steps.create_release.outputs.upload_url }}
-        asset_path: dist/*
-        asset_name: shunk-${{ github.ref }}.whl
-        asset_content_type: application/octet-stream

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -50,6 +50,7 @@ jobs:
 
     - name: Create Release
       uses: actions/create-release@v1
+      id: create_release
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -10,9 +10,9 @@ jobs:
     runs-on: ubuntu-latest  
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.8'  
 
@@ -28,7 +28,7 @@ jobs:
         make bdist_wheel
 
     - name: Upload Wheel as Artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: python-wheel
         path: dist/*.whl

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -18,11 +18,13 @@ jobs:
 
     - name: Install dependencies
       run: |
+        sudo apt-get update
+        sudo apt-get install make
         python -m pip install --upgrade pip
         python -m pip install wheel venv
 
     - name: Create Virtualenv and Build Wheel
       run: |
         python -m venv .venv
-        python setup.py venv
-        python setup.py bdist_wheel
+        make venv
+        make bdist_wheel

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -1,0 +1,29 @@
+name: Build Python Wheel
+
+on:
+  push:
+    branches:
+      - main  
+
+jobs:
+  build:
+    runs-on: ubuntu-latest  
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: '3.8'  
+
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install wheel
+
+    - name: Create Virtualenv and Build Wheel
+      run: |
+        python -m venv venv
+        source venv/bin/activate
+        python setup.py venv
+        python setup.py bdist_wheel

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -26,3 +26,9 @@ jobs:
         python -m venv .venv
         make venv
         make bdist_wheel
+
+    - name: Upload Wheel as Artifact
+      uses: actions/upload-artifact@v2
+      with:
+        name: python-wheel
+        path: dist/*.whl

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -19,7 +19,7 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        python -m pip install wheel
+        python -m pip install wheel venv
 
     - name: Create Virtualenv and Build Wheel
       run: |

--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,14 @@ mrproper: clean venv-clean
 
 .PHONY: bdist_wheel
 bdist_wheel: 
-	source ./venv/Scripts/activate	
+	if [ -e "./venv/Scripts/activate" ]; then
+	    # running on cygwin/windows
+	    activate="./venv/Scripts/activate"
+	else
+	    # running on Linux
+	    activate="./venv/bin/activate"
+	fi  
+	source "$${activate}"
 	${PYTHON} setup.py $@
 
 .PHONY: bdist_wininst

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # BKSTools
 
+[![Build Python Wheel](https://github.com/kcinnaySte/bkstools/actions/workflows/build_wheel.yml/badge.svg)](https://github.com/kcinnaySte/bkstools/actions/workflows/build_wheel.yml)
 BKSTools is a Python package for communicating with newer SCHUNK grippers like EGU and EGK. These grippers are called BKS grippers
 since they use the SCHUNK **B**au**K**asten**S**oftware.
 The BKSTools provide ready-to-use command line scripts and an API to interact with the BKS grippers from your own Python code.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # BKSTools
 
 [![Build Python Wheel](https://github.com/kcinnaySte/bkstools/actions/workflows/build_wheel.yml/badge.svg)](https://github.com/kcinnaySte/bkstools/actions/workflows/build_wheel.yml)
+
 BKSTools is a Python package for communicating with newer SCHUNK grippers like EGU and EGK. These grippers are called BKS grippers
 since they use the SCHUNK **B**au**K**asten**S**oftware.
 The BKSTools provide ready-to-use command line scripts and an API to interact with the BKS grippers from your own Python code.

--- a/pyschunk/tools/util.py
+++ b/pyschunk/tools/util.py
@@ -67,6 +67,7 @@ import os
 import time
 import re
 import argparse
+import threading
 
 # To be able to output colors in windows console we need colorama.
 # This might slow down output, so we only want to import it if
@@ -623,7 +624,8 @@ def SetExitHandler( func, remove=False ):
         except ImportError:
             version = ".".join(map(str, sys.version_info[:2]))
             raise Exception("pywin32 not installed for Python " + version)
-    else:
+    elif threading.current_thread().ident == threading.main_thread().ident:
+        # only set the exit handler for the main thread
         import signal
         signal.signal(signal.SIGTERM, func)
 

--- a/pyschunk/tools/util.py
+++ b/pyschunk/tools/util.py
@@ -67,7 +67,7 @@ import os
 import time
 import re
 import argparse
-import threading
+#import threading
 
 # To be able to output colors in windows console we need colorama.
 # This might slow down output, so we only want to import it if
@@ -624,10 +624,10 @@ def SetExitHandler( func, remove=False ):
         except ImportError:
             version = ".".join(map(str, sys.version_info[:2]))
             raise Exception("pywin32 not installed for Python " + version)
-    elif threading.current_thread().ident == threading.main_thread().ident:
+    #elif threading.current_thread().ident == threading.main_thread().ident:
         # only set the exit handler for the main thread
-        import signal
-        signal.signal(signal.SIGTERM, func)
+        #import signal
+        #signal.signal(signal.SIGTERM, func)
 
 eExitState = enum('RUNNING', 'EXITING', 'EXITED')
 _exit_state = None


### PR DESCRIPTION
Because the main gripper uses  `pyschunk/tools/util.py` and the import is used in the main gripper component, the component was not able to be imported in an other thread than the main thread.

Therefore I suggest to initialize the exit handler only in the main thread.